### PR TITLE
Add Successor government to reputation missions

### DIFF
--- a/data/missions/mod settings.txt
+++ b/data/missions/mod settings.txt
@@ -167,6 +167,7 @@ mission "Omnis: mod settings"
 				"reputation: Sheragi" = 1
 				"reputation: Silent Ones" = 1
 				"reputation: Smuggler (Hai Trafficker)" = 1
+				"reputation: Successor" = 0
 				"reputation: Syndicate" = 2
 				"reputation: Syndicate (Extremist)" = -1000
 				"reputation: Team Blue" = -1000
@@ -290,6 +291,7 @@ mission "Omnis: mod settings"
 				"reputation: Silent Ones" = 1000
 				"reputation: Sheragi" = 1000
 				"reputation: Smuggler (Hai Trafficker)" = 1000
+				"reputation: Successor" = 1000
 				"reputation: Syndicate" = 1000
 				"reputation: Syndicate (Extremist)" = 1000
 				"reputation: Team Blue" = 1000


### PR DESCRIPTION
While the many Houses governments are included in the Omnis reputation set missions, the default `Successor` government was not. This PR fixes that.