### PR TITLE
Add Incipias and Successors to main system faction wheel

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -79,67 +79,75 @@ system "Omnis"
 		sprite "asteroid/yottrite/spin"
 	object " Bunrodea"
 		distance 1600
-		offset 21
+		offset 19
 		sprite "ship/chigiriki"
 	object " Coalition"
 		distance 1600
-		offset 42
+		offset 38
 		sprite "ship/heliarch punisher"
 	object " Drak"
 		distance 1600
-		offset 64
+		offset 57
 		sprite "ship/archon"
 	object " Gegno"
 		distance 1600
-		offset 85
+		offset 76
 		sprite "ship/gegno augen"
 	object " Hai"
 		distance 1600
-		offset 106
+		offset 95
 		sprite "ship/hai shield beetle"
 	object " Human"
 		distance 1600
-		offset 127
+		offset 114
 		sprite "ship/carrier"
 	object " Iije"
 		distance 1600
-		offset 148
+		offset 133
 		sprite "ship/ayym/ayym"
+	object " Incipias"
+		distance 1600
+		offset 152
+		sprite "ship/venta"
 	object " Ka'het"
 		distance 1600
-		offset 169
+		offset 171
 		sprite "ship/vareti'het"
 	object " Korath"
 		distance 1600
-		offset 191
+		offset 190
 		sprite "ship/raider"
 	object " Pug"
 		distance 1600
-		offset 212
+		offset 209
 		sprite "ship/pug arfecta"
 	object " Quarg"
 		distance 1600
-		offset 233
+		offset 228
 		sprite "ship/wardragon"
 	object " Remnant"
 		distance 1600
-		offset 254
+		offset 247
 		sprite "ship/albatross"
 	object " Rulei"
 		distance 1600
-		offset 275
+		offset 266
 		sprite "ship/vyuir/vyuir"
 	object " Sheragi"
 		distance 1600
-		offset 296
+		offset 285
 		sprite "ship/emeraldsword"
+	object " Successors"
+		distance 1600
+		offset 304
+		sprite "ship/aaulqra"
 	object " Vyrmeid"
 		distance 1600
-		offset 318
+		offset 323
 		sprite "ship/astral cetacean/astral"
 	object " Wanderer"
 		distance 1600
-		offset 339
+		offset 342
 		sprite "ship/hurricane"
 	object " Whispering Void"
 		distance 1600

--- a/data/objects.txt
+++ b/data/objects.txt
@@ -690,6 +690,17 @@ planet "  Sheragi"
 	shipyard "omnis"
 	outfitter "sheragi"
 	shipyard "sheragi"
+planet " Successors"
+	government "Faction"
+	bribe 0
+	description ""
+	port "Settings"
+		recharges all
+		services all
+	outfitter "omnis"
+	shipyard "omnis"
+	shipyard "successors"
+	outfitter "successors"
 planet "  Successors"
 	bribe 0
 	description ""


### PR DESCRIPTION
This PR adds Incipias and Successor ship "planets" to the main Omnis system in the big faction wheel with their siblings. All the faction wheel planets get slightly closer together (from 21 degrees to 19) but nothing overlaps or looks out of place.

![1729994586](https://github.com/user-attachments/assets/1a6aa487-f86e-4bb4-a259-3a6bec309504)
