### PR TITLE
Update access.txt

### DIFF
--- a/data/missions/access.txt
+++ b/data/missions/access.txt
@@ -3,9 +3,21 @@ mission "Omnis: open wormholes"
 	landing
 	on offer
 		event "Omnis: open wormholes"
+		set "omnis: wormholes fine"
 		fail
 	to offer
 		has "omnisStart"
+
+mission "Omnis: wormhole compatibility"
+	invisible
+	landing
+	to offer
+		has "omnisStart"
+		not "omnis: wormholes fine"
+	on offer
+		event "omnis: no faction wormholes"
+		event "omnis: faction wormholes"
+		fail
 
 event "Omnis: open wormholes"
 	system "Rutilicus"

--- a/data/missions/access.txt
+++ b/data/missions/access.txt
@@ -28,7 +28,7 @@ event "Omnis: open wormholes"
 			distance 900
 			offset 84.7
 			sprite "sprite/wispGreen"
-	system "Vara K'chrai"
+	system "Ka'ch'chrai"
 		add object "wandererGatewayOmnis"
 			distance 900
 			offset 105.88
@@ -105,7 +105,7 @@ event "omnis: faction wormholes"
 			distance 900
 			offset 84.7
 			sprite "sprite/wispGreen"
-	system "Vara K'chrai"
+	system "Ka'ch'chrai"
 		add object "wandererGatewayOmnis"
 			distance 900
 			offset 105.88
@@ -177,7 +177,7 @@ event "omnis: no faction wormholes"
 			distance 900
 			offset 84.7
 			sprite "sprite/wispGreen"
-	system "Vara K'chrai"
+	system "Ka'ch'chrai"
 		remove object "wandererGatewayOmnis"
 			distance 900
 			offset 105.88


### PR DESCRIPTION
Updates a typo where the system was written as "Vara K'chrai" (planet name) to "Ka'ch'chrai" (system name). Fixes the issue of the Wander to Omnis wormhole not appearing. I'm not sure how this will impact existing saves. This is my first GitHub contribution, so  I hope I've done this correctly. 