### PR TITLE
Revert Milky Way path change

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -1,6 +1,6 @@
 galaxy "omnis"
 	pos 0 -10000
-	sprite "map/milky way"
+	sprite "ui/milky way"
 		scale 0.6
 system "Omnis"
 	"jump range" 3000


### PR DESCRIPTION
From #96, the Milky Way error generated there was based on an out-of-date plugin. This reverts the change back to be error-free.